### PR TITLE
Adding mask=True parameter to Pyrodigal to prevent unknown genes 'X' …

### DIFF
--- a/PhageBoost/get_genecalls.py
+++ b/PhageBoost/get_genecalls.py
@@ -19,7 +19,7 @@ def parse_genecall(contig,gene,i):
 #@bbcachier
 def get_genecalls_for_contig(contig, meta=True):
     seq = str(contig.seq)
-    p = pyrodigal.Pyrodigal(meta=meta)
+    p = pyrodigal.Pyrodigal(meta=meta, mask=True)
     if not meta: p.train(seq)
     a = p.find_genes(seq)
     genecalls = [parse_genecall(contig, gene, i) for i, gene in enumerate(p.find_genes(seq))]


### PR DESCRIPTION
…being predicted across unknown nucleotides and subsequently preventing BioSeq.utils.ProtParam.ProteinAnalysis from breaking.